### PR TITLE
add hashable instance for Mod

### DIFF
--- a/Data/Mod/Word.hs
+++ b/Data/Mod/Word.hs
@@ -33,6 +33,7 @@ import Prelude as P hiding (even)
 import Control.Exception
 import Control.DeepSeq
 import Data.Bits
+import Data.Hashable
 import Data.Ratio
 #ifdef MIN_VERSION_semirings
 import Data.Euclidean (GcdDomain(..), Euclidean(..), Field)
@@ -83,6 +84,8 @@ newtype Mod (m :: Nat) = Mod
 #endif
 
 instance NFData (Mod m)
+
+instance Hashable (Mod m)
 
 instance KnownNat m => Show (Mod m) where
   show m = "(" ++ show (unMod m) ++ " `modulo` " ++ show (natVal m) ++ ")"

--- a/Data/Mod/Word.hs
+++ b/Data/Mod/Word.hs
@@ -78,14 +78,12 @@ newtype Mod (m :: Nat) = Mod
   -- (9 `modulo` 10)
   }
 #ifdef MIN_VERSION_vector
-  deriving (Eq, Ord, Generic, Storable, Prim)
+  deriving (Eq, Hashable, Ord, Generic, Storable, Prim)
 #else
-  deriving (Eq, Ord, Generic, Storable)
+  deriving (Eq, Hashable, Ord, Generic, Storable)
 #endif
 
 instance NFData (Mod m)
-
-instance Hashable (Mod m)
 
 instance KnownNat m => Show (Mod m) where
   show m = "(" ++ show (unMod m) ++ " `modulo` " ++ show (natVal m) ++ ")"

--- a/mod.cabal
+++ b/mod.cabal
@@ -36,6 +36,7 @@ library
   build-depends:
     base >=4.10 && <5,
     deepseq,
+    hashable,
     integer-gmp <1.2
   if flag(semirings)
     build-depends:


### PR DESCRIPTION
It would be nice for Mod to have a hashable instance to remove some orphaned instances from the [haskell-language-server](https://github.com/haskell/haskell-language-server).