### PR TITLE
Update documentation for `GcdDomain`, `Euclidean`, `Field` instances

### DIFF
--- a/Data/Mod.hs
+++ b/Data/Mod.hs
@@ -265,7 +265,7 @@ instance KnownNat m => GcdDomain (Mod m) where
     where
       m = natVal l
       l = Mod $ if m > 1 then Prelude.lcm (Prelude.gcd m x) (Prelude.gcd m y) else 0
-  coprime x y = Data.Euclidean.gcd x y == 1
+  coprime x y = Data.Euclidean.gcd x y == one
 
 -- | 'Mod' @m@ is not even an
 -- <https://en.wikipedia.org/wiki/Integral_domain integral domain> for
@@ -280,6 +280,7 @@ instance KnownNat m => GcdDomain (Mod m) where
 --
 instance KnownNat m => Euclidean (Mod m) where
   degree = unMod
+  {-# INLINABLE degree #-}
 
   quotRem (Mod 0) _ = (Mod 0, Mod 0)
   quotRem _ (Mod 0) = throw DivideByZero

--- a/Data/Mod.hs
+++ b/Data/Mod.hs
@@ -243,7 +243,7 @@ instance KnownNat m => Ring (Mod m) where
 --
 -- The instance is lawful only for
 -- <https://en.wikipedia.org/wiki/Prime_number prime> @m@, otherwise
--- 'Data.Euclidean.divide' returns any of quotients.
+-- @'Data.Euclidean.divide' x y@ tries to return any @Just z@ such that @x == y * z@.
 --
 instance KnownNat m => GcdDomain (Mod m) where
   divide (Mod 0) _ = Just (Mod 0)
@@ -275,7 +275,7 @@ instance KnownNat m => GcdDomain (Mod m) where
 -- The instance is lawful only for
 -- <https://en.wikipedia.org/wiki/Prime_number prime> @m@, otherwise
 -- we try to do our best:
--- 'Data.Euclidean.quot' returns any of quotients,
+-- @'Data.Euclidean.quot' x y@ returns any @z@ such that @x == y * z@,
 -- 'Data.Euclidean.rem' is not always 0, and both can throw 'DivideByZero'.
 --
 instance KnownNat m => Euclidean (Mod m) where

--- a/Data/Mod/Word.hs
+++ b/Data/Mod/Word.hs
@@ -231,7 +231,7 @@ instance KnownNat m => Ring (Mod m) where
 --
 -- The instance is lawful only for
 -- <https://en.wikipedia.org/wiki/Prime_number prime> @m@, otherwise
--- 'Data.Euclidean.divide' returns any of quotients.
+-- @'Data.Euclidean.divide' x y@ tries to return any @Just z@ such that @x == y * z@.
 --
 instance KnownNat m => GcdDomain (Mod m) where
   divide (Mod 0) !_ = Just (Mod 0)
@@ -263,7 +263,7 @@ instance KnownNat m => GcdDomain (Mod m) where
 -- The instance is lawful only for
 -- <https://en.wikipedia.org/wiki/Prime_number prime> @m@, otherwise
 -- we try to do our best:
--- 'Data.Euclidean.quot' returns any of quotients,
+-- @'Data.Euclidean.quot' x y@ returns any @z@ such that @x == y * z@,
 -- 'Data.Euclidean.rem' is not always 0, and both can throw 'DivideByZero'.
 --
 instance KnownNat m => Euclidean (Mod m) where


### PR DESCRIPTION
Closes #20.

I applied the documentation patches to `Data.Mod.Word` as well and tried to clarify the behaviour of `divide` & `quot` for non-prime moduli.